### PR TITLE
Filter out the unfilled rows in model profiles to pass the typecheck

### DIFF
--- a/ai4good/params/param_store.py
+++ b/ai4good/params/param_store.py
@@ -74,7 +74,7 @@ class SimpleParamStore(ParamStore):
 
     def get_profiles(self, model: str) -> List[str]:
         df = self._read_csv(model + "_profile_params.csv")
-        return df['Profile'].unique().tolist()
+        return df['Profile'].dropna().unique().tolist()
 
     def get_params(self, model: str, profile: str) -> pd.DataFrame:
         df = self._read_csv(model + "_profile_params.csv")


### PR DESCRIPTION
The model profile CSV for ABM has some unfilled rows which were causing some unhappiness from typeguard